### PR TITLE
Add quotation marks around attribute selectors for use with Enzyme

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ const xPathToCss = expr => {
 
             if (match['contained']) {
                 if (match['cattr'].indexOf('@') === 0) {
-                    attr = '[' + match['cattr'].replace(/^@/, '') + '*=' + match['cvalue'] + ']';
+                    attr = '[' + match['cattr'].replace(/^@/, '') + '*="' + match['cvalue'] + '"]';
                 } else {
                     throw new Error('Invalid or unsupported XPath attribute: ' + match['cattr']);
                 }
@@ -130,7 +130,7 @@ const xPathToCss = expr => {
                         if (match['mvalue'].indexOf(' ') !== -1) {
                             match['mvalue'] = '\"' + match['mvalue'].replace(/^\s+|\s+$/,'') + '\"';
                         }
-                        attr = '[' + match['mattr'].replace('@', '') + '=' + match['mvalue'] + ']';
+                        attr = '[' + match['mattr'].replace('@', '') + '="' + match['mvalue'] + '"]';
                         break;
                 }
             } else if (match['idvalue']) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xpath-to-css",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "title": "XPath to CSS",
   "description": "Utility function for converting XPath expressions to CSS selectors",
   "main": "index.js",

--- a/test.js
+++ b/test.js
@@ -24,7 +24,7 @@ test('conversion', function(assert) {
   assert.equal(actual, expected);
 
   actual = xPathToCss('//div[@id="foo"][2]/span[@class="bar"]//a[contains(@class, "baz")]//img[1]');
-  expected = 'div#foo:nth-of-type(2) > span.bar a[class*=baz] img:first-of-type';
+  expected = 'div#foo:nth-of-type(2) > span.bar a[class*="baz"] img:first-of-type';
   assert.equal(actual, expected);
 
   assert.end();


### PR DESCRIPTION
Enzyme requires css attribute selector values to be surrounded in quotation marks (https://airbnb.io/enzyme/docs/api/selector.html#1-a-valid-css-selector).  This will add the quotation marks around any attributes by default.