### PR TITLE
Update regex pattern for tag in getValidationRegex function to support tag names of any lengths

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,7 @@ const getValidationRegex = () => {
         ")";
 
     const subRegexes = {
-        "tag": "([a-zA-Z][a-zA-Z0-9:-]{0,20}|\\*)",
+        "tag": "([a-zA-Z][a-zA-Z0-9:-]*|\\*)",
         "attribute": "[.a-zA-Z_:][-\\w:.]*(\\(\\))?)",
         "value": "\\s*[\\w/:][-/\\w\\s,:;.]*"
     };


### PR DESCRIPTION
This package only supports tag names up to 20 characters. I altered the regex to support tags of any length.

I understand that number 20 is hardcoded due to some performance reasons, but it causes bugs in lots of cases.

Example:

```
//atomic-result-list1234567//atomic-result//product-result-subtitle//span
```
Result:
```
atomic-result-list123 atomic-result product-result-subtit span
```
Expected:
```
atomic-result-list1234567 atomic-result product-result-subtitle span
```